### PR TITLE
[Patch] Version & file support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ GPL-3.0 - See [LICENSE](LICENSE) for details.
 - **Alpha (Protostar)**: `protostar-x.x.x`
 - **Beta (Nova)**: `nova-x.x.x`
 - **Release (Supernova)**: `supernova-x.x.x`
-- **Snapshots (Pulsar)**: `type-x.x.x-pulsar.YYMMDD`
+- **Snapshots (Pulsar)**: `type-x.x.x-pulsar.YYMMDD.GITHASH`
 
 Current version: **nebula-0.0.0**
 Snapshot/Github Actions Build version scheme: **nebula-0.0.1-pulsar.YYMMDD**

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -156,9 +156,16 @@ cargo build
 # Release build
 cargo build --release
 
-# Snapshot build (optimized but with pulsar timestamp)
+# Snapshot build (optimized with pulsar timestamp and git commit hash)
 SNAPSHOT=1 cargo build --profile=snapshot
 ```
+
+Version format:
+- **Debug**: `nebula-X.Y.Z-pulsar.YYMMDD`
+- **Snapshot**: `nebula-X.Y.Z-pulsar.YYMMDD.GITHASH`
+- **Release**: `nebula-X.Y.Z`
+
+The git commit hash ensures snapshot builds have a unique identifier that stays the same unless changes are committed.
 
 ## Testing
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+// build.rs
+// Cargo build script to capture git information at compile time
+
+use std::process::Command;
+
+fn main() {
+    // Get git commit hash (short version)
+    if let Ok(output) = Command::new("git")
+        .args(&["rev-parse", "--short", "HEAD"])
+        .output()
+    {
+        if output.status.success() {
+            let git_hash = String::from_utf8_lossy(&output.stdout);
+            let git_hash = git_hash.trim();
+            println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+        }
+    }
+    
+    // Rerun if git HEAD changes (commits made)
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/heads");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,13 @@ fn main() {
     // Try to read and execute the file
     let filename = &args[1];
     
+    // Check if file has .nvq extension
+    if !filename.ends_with(".nvq") {
+        eprintln!("Error: File must have .nvq extension");
+        eprintln!("Usage: noviq <file.nvq>");
+        process::exit(1);
+    }
+    
     match fs::read_to_string(filename) {
         Ok(contents) => {
             if let Err(e) = execute_program(&contents) {

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -6,7 +6,8 @@
 /// 
 /// Handles version string generation based on build type:
 /// - Release builds: nebula-X.Y.Z
-/// - Debug/Snapshot builds: nebula-X.Y.Z-pulsar.YYMMDD
+/// - Debug builds: nebula-X.Y.Z-pulsar.YYMMDD
+/// - Snapshot builds: nebula-X.Y.Z-pulsar.YYMMDD.BUILD
 
 /// Get the current version string for Noviq
 pub fn get_version() -> String {
@@ -17,13 +18,30 @@ pub fn get_version() -> String {
     // Check if SNAPSHOT environment variable is set during build
     let is_snapshot = option_env!("SNAPSHOT").is_some();
     
-    if is_snapshot || cfg!(debug_assertions) {
-        // Snapshot or Debug build - use snapshot format
+    if is_snapshot {
+        // Snapshot build - include date and build number
+        let date = chrono::Local::now().format("%y%m%d").to_string();
+        let build_number = get_build_number();
+        format!("{}-pulsar.{}.{}", base_version, date, build_number)
+    } else if cfg!(debug_assertions) {
+        // Debug build - use snapshot format without build number
         let date = chrono::Local::now().format("%y%m%d").to_string();
         format!("{}-pulsar.{}", base_version, date)
     } else {
         // Release build - use base version
         base_version
+    }
+}
+
+/// Get build number based on git commit hash
+/// Returns the short git hash if available, otherwise "dev"
+fn get_build_number() -> String {
+    // Try to get git commit hash at compile time
+    if let Some(git_hash) = option_env!("GIT_HASH") {
+        git_hash.to_string()
+    } else {
+        // Fallback to "dev" if git hash not available
+        "dev".to_string()
     }
 }
 


### PR DESCRIPTION
- Made snapshots include githash.
- Locked the interpreter to only use .nvq files.